### PR TITLE
Fix handling of the `destination` input

### DIFF
--- a/.github/workflows/test-pishrink.yml
+++ b/.github/workflows/test-pishrink.yml
@@ -20,9 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         destination:
-          - ''
-          - 'destination.img'
-          - 'destination.img.gz'
+          - name: implicit
+            path: ''
+          - name: explicit
+            path: 'destination.img'
+          - name: explicit-gz
+            path: 'destination.img.gz'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -52,14 +55,14 @@ jobs:
         uses: ./
         with:
           image: cowsay-image.img
-          destination: ${{ matrix.destination }}
+          destination: ${{ matrix.destination.path }}
           compress: gzip
           compress-parallel: true
 
       - name: Upload image to Job Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: rpi-cowsay-arm64-latest
+          name: rpi-cowsay-${{ matrix.destination.name }}-arm64-latest
           path: ${{ steps.shrink-image.outputs.destination }}
           if-no-files-found: error
           retention-days: 0

--- a/.github/workflows/test-pishrink.yml
+++ b/.github/workflows/test-pishrink.yml
@@ -48,6 +48,7 @@ jobs:
           pifile: cowsay.Pifile
 
       - name: Shrink the image
+        id: shrink-image
         uses: ./
         with:
           image: cowsay-image.img
@@ -59,7 +60,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rpi-cowsay-arm64-latest
-          path: cowsay-image.img.gz
+          path: ${{ steps.shrink-image.outputs.destination }}
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/.github/workflows/test-pishrink.yml
+++ b/.github/workflows/test-pishrink.yml
@@ -14,8 +14,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  strategy:
+    fail-fast: false
+    matrix:
+      destination:
+        - ''
+        - 'destination.img'
+        - 'destination.img.gz'
   build:
-    name: Build image
+    name: Build test image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -44,6 +51,7 @@ jobs:
         uses: ./
         with:
           image: cowsay-image.img
+          destination: ${{ matrix.destination }}
           compress: gzip
           compress-parallel: true
 

--- a/.github/workflows/test-pishrink.yml
+++ b/.github/workflows/test-pishrink.yml
@@ -14,15 +14,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  strategy:
-    fail-fast: false
-    matrix:
-      destination:
-        - ''
-        - 'destination.img'
-        - 'destination.img.gz'
   build:
     name: Build test image
+    strategy:
+      fail-fast: false
+      matrix:
+        destination:
+          - ''
+          - 'destination.img'
+          - 'destination.img.gz'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ downloading a base image, expanding it, and modifying its filesystem (e.g. with
   run: wget http://some-website.com/large-rpi-sd-card-image.img
 
 - name: Shrink image
-  uses: ethanjli/pishrink-action@v0.1.0
+  uses: ethanjli/pishrink-action@v0.1.1
   with:
     image: large-rpi-sd-card-image.img
     compress: gzip
@@ -38,7 +38,7 @@ downloading a base image, expanding it, and modifying its filesystem (e.g. with
   run: wget http://some-website.com/large-rpi-sd-card-image.img
 
 - name: Shrink image
-  uses: ethanjli/pishrink-action@v0.1.0
+  uses: ethanjli/pishrink-action@v0.1.1
   with:
     image: large-rpi-sd-card-image.img
     compress: xz
@@ -60,7 +60,7 @@ downloading a base image, expanding it, and modifying its filesystem (e.g. with
   run: wget http://some-website.com/large-rpi-sd-card-image.img
 
 - name: Shrink image
-  uses: ethanjli/pishrink-action@v0.1.0
+  uses: ethanjli/pishrink-action@v0.1.1
   with:
     image: large-rpi-sd-card-image.img
     destination: result.img.gz
@@ -85,7 +85,7 @@ downloading a base image, expanding it, and modifying its filesystem (e.g. with
 
 - name: Shrink image
   id: shrink-image
-  uses: ethanjli/pishrink-action@v0.1.0
+  uses: ethanjli/pishrink-action@v0.1.1
   with:
     image: large-rpi-sd-card-image.img
     compress: gzip
@@ -135,7 +135,7 @@ jobs:
           pifile: cowsay.Pifile
 
       - name: Shrink the image
-        uses: ethanjli/pishrink-action@v0.1.0
+        uses: ethanjli/pishrink-action@v0.1.1
         with:
           image: cowsay-image.img
           compress: gzip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PiShrink GitHub Action
 
-GitHub action to run [PiShrink](https://github.com/Drewsif/PiShrink) on a Raspberry Pi SD card image.
+GitHub action to process a Raspberry Pi SD card image using [PiShrink](https://github.com/Drewsif/PiShrink).
 
 ## Basic Usage Examples
 

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
           gzip | gz)
             flags="$flags -z"
             if [ ! -z "${{ inputs.destination }}" ]; then
-              destination="$(sed 's~\.gz$~~' "${{ inputs.destination }}")"
+              destination="$(echo "${{ inputs.destination }}" | sed -e 's~\.gz$~~')"
               echo "destination=$destination.gz" >> $GITHUB_OUTPUT
             else
               echo "destination=${{ inputs.image }}.gz" >> $GITHUB_OUTPUT
@@ -66,7 +66,7 @@ runs:
           xz)
             flags="$flags -Z"
             if [ ! -z "${{ inputs.destination }}" ]; then
-              destination="$(sed 's~\.xz$~~' "${{ inputs.destination }}")"
+              destination="$(echo "${{ inputs.destination }}" | sed -e 's~\.xz$~~')"
               echo "destination=$destination.xz" >> $GITHUB_OUTPUT
             else
               echo "destination=${{ inputs.image }}.xz" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR attempts to fix how the action handles the `destination` input, and modifies a GitHub Actions workflow to test the various kinds of inputs that might be provided.